### PR TITLE
feat: add api to activate subscriptions to offers

### DIFF
--- a/models.go
+++ b/models.go
@@ -59,3 +59,18 @@ type PremiumSMSResponse struct {
 	Direction    string `json:"direction"`
 	State        string `json:"state"`
 }
+
+// Subscription represents the response that is returned when activating a subscription to an offer
+type Subscription struct {
+	GUID             string `json:"guid"`
+	Gateway          string `json:"gateway"`
+	Offer            string `json:"offer"`
+	Msisdn           string `json:"msisdn"`
+	LinkID           string `json:"link_id"`
+	ActivationDate   string `json:"activation_date"`
+	DeactivationDate any    `json:"deactivation_date"`
+	DeactivationType string `json:"deactivation_type"`
+	Sms              []any  `json:"sms"`
+	Created          string `json:"created"`
+	Updated          string `json:"updated"`
+}

--- a/sms_test.go
+++ b/sms_test.go
@@ -250,3 +250,167 @@ func TestSILCommsLib_SendPremiumSMS(t *testing.T) {
 		})
 	}
 }
+
+func TestSILCommsLib_ActivateSubscription(t *testing.T) {
+	ctx := context.Background()
+	type args struct {
+		ctx    context.Context
+		offer  string
+		msisdn string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+	}{
+		{
+			name: "Happy case: activate subscription",
+			args: args{
+				ctx:    ctx,
+				offer:  "01262626626",
+				msisdn: gofakeit.Phone(),
+			},
+			wantErr: false,
+		},
+		{
+			name: "Sad case: invalid status code",
+			args: args{
+				ctx:    ctx,
+				offer:  "01262626626",
+				msisdn: gofakeit.Phone(),
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			httpmock.Activate()
+			defer httpmock.DeactivateAndReset()
+			silcomms.MockLogin()
+
+			l := silcomms.MustNewSILCommsLib()
+
+			if tt.name == "Happy case: activate subscription" {
+				httpmock.RegisterResponder(http.MethodPost, fmt.Sprintf("%s/v1/sms/subscriptions/", silcomms.BaseURL), func(r *http.Request) (*http.Response, error) {
+					resp := silcomms.APIResponse{
+						Status:  silcomms.StatusSuccess,
+						Message: "success",
+						Data: map[string]interface{}{
+							"guid":   "123456",
+							"offer":  "123456",
+							"msisdn": "123456",
+						},
+					}
+					return httpmock.NewJsonResponse(http.StatusOK, resp)
+				})
+			}
+
+			if tt.name == "Sad case: invalid status code" {
+				httpmock.RegisterResponder(http.MethodPost, fmt.Sprintf("%s/v1/sms/subscriptions/", silcomms.BaseURL), func(r *http.Request) (*http.Response, error) {
+					return httpmock.NewJsonResponse(http.StatusUnauthorized, nil)
+				})
+			}
+
+			got, err := l.ActivateSubscription(tt.args.ctx, tt.args.offer, tt.args.msisdn)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("SILCommsLib.ActivateSubscription() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr && got == false {
+				t.Errorf("SILCommsLib.ActivateSubscription() expected response not to be false for %v", tt.name)
+				return
+			}
+		})
+	}
+}
+
+func TestSILCommsLib_GetSubscriptions(t *testing.T) {
+	ctx := context.Background()
+	type args struct {
+		ctx         context.Context
+		queryParams map[string]string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+	}{
+		{
+			name: "Happy case: get subscription",
+			args: args{
+				ctx: ctx,
+				queryParams: map[string]string{
+					"msisdn": gofakeit.Phone(),
+					"offer":  "01262626626",
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "Sad case: invalid status code",
+			args: args{
+				ctx: ctx,
+				queryParams: map[string]string{
+					"msisdn": gofakeit.Phone(),
+					"offer":  "01262626626",
+				},
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			httpmock.Activate()
+			defer httpmock.DeactivateAndReset()
+			silcomms.MockLogin()
+
+			l := silcomms.MustNewSILCommsLib()
+
+			if tt.name == "Happy case: get subscription" {
+				httpmock.RegisterResponder(http.MethodGet, fmt.Sprintf("%s/v1/sms/subscriptions/", silcomms.BaseURL), func(r *http.Request) (*http.Response, error) {
+					resp := silcomms.APIResponse{
+						Status:  silcomms.StatusSuccess,
+						Message: "success",
+						Data: map[string]interface{}{
+							"count":    1,
+							"next":     nil,
+							"previous": nil,
+							"results": []map[string]interface{}{
+								{
+									"guid":              "e602b8b8-9591-4526-915d-57ef2579d8c4",
+									"gateway":           "SAFARICOM",
+									"offer":             "0022345234",
+									"msisdn":            "+254722345678",
+									"link_id":           "123123123123123",
+									"activation_date":   "2022-08-04 14:11:17.206377+03:00",
+									"deactivation_date": nil,
+									"deactivation_type": "USER_INITIATED",
+									"sms":               []string{},
+									"created":           "2022-08-04 14:11:17.206377+03:00",
+									"updated":           "2022-08-04 14:11:17.206377+03:00",
+								},
+							},
+						},
+					}
+					return httpmock.NewJsonResponse(http.StatusOK, resp)
+				})
+			}
+
+			if tt.name == "Sad case: invalid status code" {
+				httpmock.RegisterResponder(http.MethodGet, fmt.Sprintf("%s/v1/sms/subscriptions/", silcomms.BaseURL), func(r *http.Request) (*http.Response, error) {
+					return httpmock.NewJsonResponse(http.StatusUnauthorized, nil)
+				})
+			}
+
+			got, err := l.GetSubscriptions(tt.args.ctx, tt.args.queryParams)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("SILCommsLib.GetSubscriptions() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr && got == nil {
+				t.Errorf("SILCommsLib.GetSubscriptions() expected response not to be nil for %v", tt.name)
+				return
+			}
+		})
+	}
+}


### PR DESCRIPTION
CHANGELOG:
- add api to activate subscriptions to offers
- add api to retrieve a subscription based on the offercode and msisdn